### PR TITLE
Pins the version of DYAD for the 2023 ECP Tutorial Material

### DIFF
--- a/2023-ECP/JupyterNotebook/Dockerfile.spawn
+++ b/2023-ECP/JupyterNotebook/Dockerfile.spawn
@@ -20,6 +20,7 @@ RUN pip3 install --upgrade pip \
 
 RUN git clone https://github.com/flux-framework/dyad.git \
     && cd dyad \
+    && git checkout v0.1.1 \
     && cp -r docs/demos/ecp_feb_2023 .. \
     && ./autogen.sh \
     && ./configure --prefix=/usr CC=$(which gcc) CXX=$(which g++) \


### PR DESCRIPTION
There are a few upcoming updates to DYAD that, when pushed, will break the 2023 ECP tutorial material for DYAD. This PR pins the version of DYAD in `2023-ECP/JupyterNotebook/Dockerfile.spawn` so that the tutorial material will not break.