### PR TITLE
Cluster and README updates, add tutorial slides

### DIFF
--- a/2023-RADIUSS-AWS/JupyterNotebook/README.md
+++ b/2023-RADIUSS-AWS/JupyterNotebook/README.md
@@ -55,7 +55,11 @@ Here is how to create an equivalent cluster on AWS (EKS). We will be using [eksc
 you should install.
 
 ```bash
-$ eksctl create cluster --config-file aws/eksctl-config.yaml 
+# Create an EKS cluster with autoscaling with default storage
+eksctl create cluster --config-file aws/eksctl-config.yaml
+
+# Create an EKS cluster with io1 node storage but no autoscaling, used for the RADIUSS 2023 tutorial
+eksctl create cluster --config-file aws/eksctl-radiuss-tutorial-2023.yaml
 ```
 
 You can find vanilla (manual) instructions [here](https://z2jh.jupyter.org/en/stable/kubernetes/amazon/step-zero-aws-eks.html) if you
@@ -68,7 +72,15 @@ kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernete
 And install the cluster-autoscaler:
 
 ```bash
-$ kubectl apply -f aws/cluster-autoscaler-autodiscover.yaml 
+kubectl apply -f aws/cluster-autoscaler-autodiscover.yaml 
+```
+
+If you want to use a different storage class than the default (`gp2`), you also need to create the new storage class (`io1` here) and set it as the default sc:
+
+```bash
+kubectl apply -f aws/storageclass.yaml
+kubectl patch storageclass io1 -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+kubectl patch storageclass gp2 -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
 ```
 
 Most of the information I needed to read about this was [here](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md) - the Jupyter documentation wasn't super helpful beyond saying to install it. Also note that I got this (seemingly working) without the `propagateASGTags` set to true, but that is something that I've seen have issue.

--- a/2023-RADIUSS-AWS/JupyterNotebook/aws/config-aws-ssl.yaml
+++ b/2023-RADIUSS-AWS/JupyterNotebook/aws/config-aws-ssl.yaml
@@ -13,6 +13,12 @@ hub:
     JupyterHub:
       admin_access: true
       authenticator_class: dummy
+  db:
+    pvc:
+      # Defaults to 1Gi
+      storage: 32Gi
+      # Add the storageclass name, defaults to gp2
+      storageClassName: io1
       
   # This is the image I built based off of jupyterhub/k8s-hub, 3.0.2 at time of writing this
   image: 
@@ -32,7 +38,7 @@ proxy:
   https:
     enabled: true
     hosts:
-      - test.flux-tutorial.com
+      - tutorial.flux-framework.org
     letsencrypt:
       contactEmail: you@email.com
 

--- a/2023-RADIUSS-AWS/JupyterNotebook/aws/config-aws-ssl.yaml
+++ b/2023-RADIUSS-AWS/JupyterNotebook/aws/config-aws-ssl.yaml
@@ -6,7 +6,7 @@
 
 # This is the concurrent spawn limit, likely should be increased (deafults to 64)
 hub:
-  concurrentSpawnLimit: 10
+  concurrentSpawnLimit: 128
   config:
     DummyAuthenticator:
       password: butter
@@ -49,7 +49,7 @@ singleuser:
     tag: "2023"
     pullPolicy: Always
   cpu:
-    limit: 1
+    limit: 2
   memory:
     limit: '4G'
   cmd: /entrypoint.sh

--- a/2023-RADIUSS-AWS/JupyterNotebook/aws/eksctl-config.yaml
+++ b/2023-RADIUSS-AWS/JupyterNotebook/aws/eksctl-config.yaml
@@ -55,7 +55,7 @@ iam:
               - "ec2:DetachVolume"
             Resource: '*'
 
-
+availabilityZones: ["us-east-2a", "us-east-2b", "us-east-2c"]
 managedNodeGroups:
   - name: ng-us-east-2a
     iam:

--- a/2023-RADIUSS-AWS/JupyterNotebook/aws/eksctl-radiuss-tutorial-2023.yaml
+++ b/2023-RADIUSS-AWS/JupyterNotebook/aws/eksctl-radiuss-tutorial-2023.yaml
@@ -1,0 +1,74 @@
+# https://www.arhea.net/posts/2020-06-18-jupyterhub-amazon-eks
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+metadata:
+  name: jupyterhub
+  region: us-east-1
+
+iam:
+  withOIDC: true
+  serviceAccounts:
+    - metadata:
+        name: ebs-csi-controller-sa
+        namespace: kube-system
+        labels:
+            aws-usage: "cluster-ops"
+            app.kubernetes.io/name: aws-ebs-csi-driver
+      attachPolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - "ec2:AttachVolume"
+              - "ec2:CreateSnapshot"
+              - "ec2:CreateTags"
+              - "ec2:CreateVolume"
+              - "ec2:DeleteSnapshot"
+              - "ec2:DeleteTags"
+              - "ec2:DeleteVolume"
+              - "ec2:DescribeInstances"
+              - "ec2:DescribeSnapshots"
+              - "ec2:DescribeTags"
+              - "ec2:DescribeVolumes"
+              - "ec2:DetachVolume"
+            Resource: '*'
+
+availabilityZones: ["us-east-1a", "us-east-1b", "us-east-1c"]
+managedNodeGroups:
+  - name: ng-us-east-1a
+    instanceType: m6a.8xlarge
+    volumeSize: 300
+    volumeType: io1
+    volumeIOPS: 15000
+    desiredCapacity: 1
+    minSize: 1
+    maxSize: 6
+    privateNetworking: true
+    availabilityZones:
+      - us-east-1a
+
+  - name: ng-us-east-1b
+    instanceType: m6a.8xlarge
+    volumeSize: 300
+    volumeType: io1
+    volumeIOPS: 15000
+    desiredCapacity: 1
+    minSize: 1
+    maxSize: 6
+    privateNetworking: true
+    availabilityZones:
+      - us-east-1b
+    # propagateASGTags: true
+
+  - name: ng-us-east-1d
+    instanceType: m6a.8xlarge
+    volumeSize: 300
+    volumeType: io1
+    volumeIOPS: 15000
+    desiredCapacity: 1
+    minSize: 1
+    maxSize: 6
+    privateNetworking: true
+    availabilityZones:
+      - us-east-1c
+    # propagateASGTags: true

--- a/2023-RADIUSS-AWS/JupyterNotebook/aws/storageclass.yaml
+++ b/2023-RADIUSS-AWS/JupyterNotebook/aws/storageclass.yaml
@@ -1,0 +1,7 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: io1
+provisioner: kubernetes.io/aws-ebs
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete


### PR DESCRIPTION
This PR adds support for changing the AWS EBS storage class, fixes a problem with spawning EC2 instances in AZs that differ from the EKS cluster, updates the README with details for changing the class, and adds the tutorial slides as a PDF.