### PR TITLE
Fix sc in README and initcontainer tag

### DIFF
--- a/2023-RADIUSS-AWS/JupyterNotebook/README.md
+++ b/2023-RADIUSS-AWS/JupyterNotebook/README.md
@@ -76,7 +76,7 @@ And install the cluster-autoscaler:
 kubectl apply -f aws/cluster-autoscaler-autodiscover.yaml 
 ```
 
-If you want to use a different storage class than the default (`gp2`), you also need to create the new storage class (`io1` here) and set it as the default sc:
+If you want to use a different storage class than the default (`gp2`), you also need to create the new storage class (`gp3` here) and set it as the default storage class:
 
 ```bash
 kubectl apply -f aws/storageclass.yaml

--- a/2023-RADIUSS-AWS/JupyterNotebook/aws/config-aws-ssl.yaml
+++ b/2023-RADIUSS-AWS/JupyterNotebook/aws/config-aws-ssl.yaml
@@ -57,7 +57,7 @@ singleuser:
   # This runs as the root user, who clones and changes ownership to uid 1000
   initContainers:
     - name: init-myservice
-      image: ghcr.io/flux-framework/flux-jupyter-init
+      image: ghcr.io/flux-framework/flux-jupyter-init:2023
       command: ["/entrypoint.sh"]
       volumeMounts:
         - name: flux-tutorial


### PR DESCRIPTION
Quick fixes for config and README. The helm config specifies the `initContainer` tag in a different way.