### PR TITLE
hotfix: flux-tree stat -> stats

### DIFF
--- a/2024-RIKEN-AWS/JupyterNotebook/flux-tree/flux-tree
+++ b/2024-RIKEN-AWS/JupyterNotebook/flux-tree/flux-tree
@@ -212,7 +212,7 @@ jsonify() {
 
     if [[ "${avail}" = "yes" ]]
     then
-        avg=$(flux ion-resource stat | grep "Avg" | awk '{print $4}')
+        avg=$(flux ion-resource stats | grep "Avg" | awk '{print $4}')
         el_match=$(awk "BEGIN {print ${avg}*${njobs}*1000000.0}")
     fi
 


### PR DESCRIPTION
Problem: stat is no longer a command, but stats is
Solution: change to stats!

Testing locally now - will report if/when it works.